### PR TITLE
Update Query.cls

### DIFF
--- a/src/classes/Query.cls
+++ b/src/classes/Query.cls
@@ -1519,6 +1519,16 @@ public class Query {
         return enforceSecurity(true);
     }
 
+    public Query enforseSObjectAccessDecision() {
+        return enforseSObjectAccessDecision(true, AccessType.READABLE);
+    }
+
+    public Query enforseSObjectAccessDecision(Boolean enforce, System.AccessType accessCheckType) {
+        this.sObjectAccessDecisionEnforced = enforce;
+        this.accessCheckType = accessCheckType;
+        return this;
+    }
+
     public String toQueryString() {
         String rawString = formQueryStringPreformat();
 
@@ -1576,7 +1586,14 @@ public class Query {
 
     public List<SObject> toSObjectList() {
         String queryString = formQueryString();
-        return Database.query(queryString);
+        List<SObject> dbResp = Database.query(queryString);
+
+        if (sObjectAccessDecisionEnforced == true) {
+            SObjectAccessDecision securityDecision = Security.stripInaccessible(this.accessCheckType, dbResp);
+            return securityDecision.getRecords();
+        }
+
+        return dbResp;
     }
 
     public List<AggregateResult> aggregate() {
@@ -2441,6 +2458,8 @@ public class Query {
 
     private static Boolean securityEnforcedGlobal = false;
     private Boolean securityEnforced = null;
+    private Boolean sObjectAccessDecisionEnforced = null;
+    private System.AccessType accessCheckType = AccessType.READABLE;
 
     private String namespace = getNamespaceFromClass();
 


### PR DESCRIPTION
Now possible to use Security.stripInaccessible() from Spring ’20 and enforce field access by AccessType.

new Query('Account').enforseSObjectAccessDecision().selectAllFields().run()